### PR TITLE
docs: Correcting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TailwindCSS Accent Colour Plugin
+# TailwindCSS Accent Color Plugin
 
 [![npm](https://img.shields.io/npm/v/tailwind-accent-color.svg?style=flat-square)](https://www.npmjs.com/package/tailwind-accent-color)
 


### PR DESCRIPTION
You otherwise spelled "color" correctly throughout the ReadMe and package name, just made a mistake in the header ;)

Edit: Can't even close this as low-effort trolling as this does mean your header doesn't match your repo name or even the package name 